### PR TITLE
Add support for `X-Script-Name` Header

### DIFF
--- a/server/src/http_server/hypermedia/routes/not_found.rs
+++ b/server/src/http_server/hypermedia/routes/not_found.rs
@@ -1,14 +1,22 @@
 use askama::Template;
-use axum::response::Response;
+use axum::{http::HeaderMap, response::Response};
 use axum_core::response::IntoResponse;
 
 #[derive(Template)]
 #[template(path = "not_found/+page.html")]
 struct NotFound<'a> {
   title: &'a str,
+  url_prefix: &'a str,
 }
 
-pub async fn get() -> Response {
-  let template = NotFound { title: "Not Found" };
+pub async fn get(headers: HeaderMap) -> Response {
+  let script_name = headers
+    .get("x-script-name")
+    .and_then(|v| v.to_str().ok())
+    .unwrap_or("");
+  let template = NotFound {
+    title: "Not Found",
+    url_prefix: script_name,
+  };
   template.into_response()
 }

--- a/server/src/http_server/hypermedia/templates/+layout.html
+++ b/server/src/http_server/hypermedia/templates/+layout.html
@@ -5,17 +5,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NUT Web - {{ title }}</title>
-    <link href="/static/style.css" rel="preload" as="style" />
-    <link href="/static/index.js" rel="preload" as="script" />
-    <link href="/static/style.css" rel="stylesheet" />
-    <link rel="icon" href="/static/icon.svg" />
+    <link href="{{url_prefix}}/static/style.css" rel="preload" as="style" />
+    <link href="{{url_prefix}}/static/index.js" rel="preload" as="script" />
+    <link href="{{url_prefix}}/static/style.css" rel="stylesheet" />
+    <link rel="icon" href="{{url_prefix}}/static/icon.svg" />
     <script>
       "use strict";
       var o=window.matchMedia("(prefers-color-scheme: dark)");
       var t=localStorage.getItem("app_theme")||(o&&o.matches&&"dark")||"light";
       if(t){document.documentElement.setAttribute("data-theme",t)}
     </script>
-    <script src="/static/index.js" defer></script>
+    <script src="{{url_prefix}}/static/index.js" defer></script>
     {% block head %}{% endblock head %}
   </head>
 
@@ -23,8 +23,8 @@
     <header>
       <div class="navbar bg-base-100">
         <div class="flex-1">
-          <a class="btn btn-ghost text-xl drop-shadow" href="/">
-            <img width="32" height="32" src="/static/icon.svg" alt="icon" />
+          <a class="btn btn-ghost text-xl drop-shadow" href="{{url_prefix}}/">
+            <img width="32" height="32" src="{{url_prefix}}/static/icon.svg" alt="icon" />
             <span class="hidden sm:inline-block"> NUT Web Monitor </span>
           </a>
         </div>

--- a/server/src/http_server/hypermedia/templates/ups_table.html
+++ b/server/src/http_server/hypermedia/templates/ups_table.html
@@ -21,7 +21,7 @@
       {% for row in ups_list %}
         <tr class="break-all">
           <td>
-            <a class="link font-bold text-primary" href="/ups/{{row.name}}">
+            <a class="link font-bold text-primary" href="{{url_prefix}}/ups/{{row.name}}">
               {{row.name}}
             </a>
           </td>
@@ -64,7 +64,7 @@
             {% endif %}
           </td>
           <td class="hidden sm:table-cell w-32">
-            <a role="button" href="/ups/{{row.name}}" class="btn btn-sm btn-outline">Details</a>
+            <a role="button" href="{{url_prefix}}/ups/{{row.name}}" class="btn btn-sm btn-outline">Details</a>
           </td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
`X-Script-Name` is a non-standard HTTP Header, proxy server can use this to tell the server which sub-path is using. 

Caddyfile for reverse proxy:
```caddy
:9001 {
    handle_path /nut-ups/* {
        uri strip_prefix /nut-ups
        reverse_proxy :9000 {
            header_up X-Script-Name /nut-ups
        }
    }
}
```
This is a simple approach for solving #17, without adding any extra configuration on webgui itself. No changes need to be made if someone don't want reverse proxy.

I only test the code against the dummy ups. So any changes are welcome.